### PR TITLE
Fix the aria-label property from showing up when there isn't one

### DIFF
--- a/src/app/public/modules/checkbox/checkbox.component.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.ts
@@ -45,7 +45,7 @@ export class SkyCheckboxComponent implements ControlValueAccessor {
    * Hidden label for screen readers.
    */
   @Input()
-  public label: string = '';
+  public label: string;
 
   /**
    * Id of label for the checkbox.


### PR DESCRIPTION
Because this property was being set to an empty string the attribute was showing up in the HTML with no value. Removing this default will ensure that the attribute only shows up if it is set by a consumer.