### PR TITLE
Added required input in checkbox component

### DIFF
--- a/src/app/public/modules/checkbox/checkbox-required-validator.directive.ts
+++ b/src/app/public/modules/checkbox/checkbox-required-validator.directive.ts
@@ -21,6 +21,8 @@ export const SKY_CHECKBOX_REQUIRED_VALIDATOR: Provider = {
  * Validator support for the `required` input on `sky-checkbox`.
  * Angular's `CheckboxRequiredValidator` only works with `input type=checkbox`. This directive
  * extends the angular validator to work with `sky-checkbox` tags.
+ * This is based on Angular Material's similar implementation:
+ * https://github.com/angular/components/blob/a415b52ead2ec202ba37edb7d7866b29dd790394/src/material/checkbox/checkbox-required-validator.ts
  */
 @Directive({
   selector: `sky-checkbox[required][formControlName],

--- a/src/app/public/modules/checkbox/checkbox-required-validator.directive.ts
+++ b/src/app/public/modules/checkbox/checkbox-required-validator.directive.ts
@@ -1,0 +1,30 @@
+import {
+  Directive,
+  forwardRef,
+  Provider
+} from '@angular/core';
+
+import {
+  CheckboxRequiredValidator,
+  NG_VALIDATORS
+} from '@angular/forms';
+
+// tslint:disable:no-forward-ref
+export const SKY_CHECKBOX_REQUIRED_VALIDATOR: Provider = {
+  provide: NG_VALIDATORS,
+  useExisting: forwardRef(() => SkyCheckboxRequiredValidatorDirective),
+  multi: true
+};
+// tslint:enable
+
+/**
+ * Validator support for the `required` input on `sky-checkbox`.
+ * Angular's `CheckboxRequiredValidator` only works with `input type=checkbox`. This directive
+ * extends the angular validator to work with `sky-checkbox` tags.
+ */
+@Directive({
+  selector: `sky-checkbox[required][formControlName],
+             sky-checkbox[required][formControl], sky-checkbox[required][ngModel]`,
+  providers: [SKY_CHECKBOX_REQUIRED_VALIDATOR]
+})
+export class SkyCheckboxRequiredValidatorDirective extends CheckboxRequiredValidator {}

--- a/src/app/public/modules/checkbox/checkbox.component.html
+++ b/src/app/public/modules/checkbox/checkbox.component.html
@@ -8,11 +8,11 @@
     [checked]="checked"
     [disabled]="disabled"
     [name]="name"
+    [required]="required"
     [tabIndex]="tabindex"
     [attr.aria-label]="label"
     [attr.aria-labelledby]="labelledBy"
     [attr.aria-required]="(required) ? true : null"
-    [attr.required]="(required) ? true : null"
     (blur)="onInputBlur()"
     (change)="onInteractionEvent($event)"/>
   <span

--- a/src/app/public/modules/checkbox/checkbox.component.html
+++ b/src/app/public/modules/checkbox/checkbox.component.html
@@ -11,6 +11,8 @@
     [tabIndex]="tabindex"
     [attr.aria-label]="label"
     [attr.aria-labelledby]="labelledBy"
+    [attr.aria-required]="(required) ? true : null"
+    [attr.required]="(required) ? true : null"
     (blur)="onInputBlur()"
     (change)="onInteractionEvent($event)"/>
   <span

--- a/src/app/public/modules/checkbox/checkbox.component.html
+++ b/src/app/public/modules/checkbox/checkbox.component.html
@@ -1,6 +1,10 @@
 <label
   class="sky-checkbox-wrapper sky-switch"
-  [ngClass]="{ 'sky-switch-disabled': disabled }">
+  [ngClass]="{
+    'sky-control-label-required': required,
+    'sky-switch-disabled': disabled
+  }"
+>
   <input
     class="sky-switch-input"
     type="checkbox"

--- a/src/app/public/modules/checkbox/checkbox.component.html
+++ b/src/app/public/modules/checkbox/checkbox.component.html
@@ -33,7 +33,3 @@
   <ng-content select="sky-checkbox-label">
   </ng-content>
 </label>
-
-<p>
-  {{ controlDir?.value }}
-</p>

--- a/src/app/public/modules/checkbox/checkbox.component.html
+++ b/src/app/public/modules/checkbox/checkbox.component.html
@@ -33,3 +33,7 @@
   <ng-content select="sky-checkbox-label">
   </ng-content>
 </label>
+
+<p>
+  {{ controlDir?.value }}
+</p>

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -31,6 +31,7 @@ import {
   SkyCheckboxModule
 } from './';
 
+// #region helpers
 /** Simple component for testing a single checkbox. */
 @Component({
   template: `
@@ -64,7 +65,7 @@ class SingleCheckboxComponent {
   template: `
   <div>
     <form>
-      <sky-checkbox name="cb" [(ngModel)]="isGood" #wut>
+      <sky-checkbox name="cb"  [(ngModel)]="isGood" [attr.required]="(required) ? true : null" #wut>
         <sky-checkbox-label>
           Be good
         </sky-checkbox-label>
@@ -75,6 +76,25 @@ class SingleCheckboxComponent {
 })
 class CheckboxWithFormDirectivesComponent {
   public isGood: boolean = false;
+  public required: boolean = false;
+}
+
+/** Simple component for testing a required template-driven checkbox. */
+@Component({
+  template: `
+  <div>
+    <form>
+      <sky-checkbox name="cb" ngModel required>
+        <sky-checkbox-label>
+          Be good
+        </sky-checkbox-label>
+      </sky-checkbox>
+    </form>
+  </div>
+  `
+})
+class CheckboxWithRequiredComponent {
+
 }
 
 /** Simple component for testing an MdCheckbox with ngModel. */
@@ -162,6 +182,7 @@ class CheckboxWithOnPushChangeDetectionComponent {
   public isChecked: boolean = false;
   constructor(public ref: ChangeDetectorRef) {}
 }
+// #endregion
 
 describe('Checkbox component', () => {
   let fixture: ComponentFixture<any>;
@@ -183,6 +204,7 @@ describe('Checkbox component', () => {
         CheckboxWithOnPushChangeDetectionComponent,
         CheckboxWithTabIndexComponent,
         CheckboxWithReactiveFormComponent,
+        CheckboxWithRequiredComponent,
         MultipleCheckboxesComponent,
         SingleCheckboxComponent
       ],
@@ -589,6 +611,40 @@ describe('Checkbox component', () => {
           fixture.detectChanges();
           expect(inputElement.checked).toBe(true);
         });
+      });
+    }));
+
+    fit('should not have required and aria-reqiured attributes', () => {
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(inputElement.getAttribute('required')).toBeNull();
+        expect(inputElement.getAttribute('aria-required')).toBeNull();
+      });
+    });
+  });
+
+  describe('with ngModel and required', () => {
+    let checkboxElement: DebugElement;
+    let inputElement: HTMLInputElement;
+    let checkboxNativeElement: HTMLElement;
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(CheckboxWithRequiredComponent);
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        checkboxElement = fixture.debugElement.query(By.directive(SkyCheckboxComponent));
+        checkboxNativeElement = checkboxElement.nativeElement;
+        inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+      });
+    }));
+
+    fit('should have required and aria-reqiured attributes', async(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(inputElement.getAttribute('required')).not.toBeNull();
+        expect(inputElement.getAttribute('aria-required')).toEqual('true');
       });
     }));
   });

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -649,6 +649,8 @@ describe('Checkbox component', () => {
     let checkboxElement: DebugElement;
     let inputElement: HTMLInputElement;
     let checkboxNativeElement: HTMLElement;
+    let ngModel: NgModel;
+    let labelElement: HTMLLabelElement;
 
     beforeEach(async(() => {
       fixture = TestBed.createComponent(CheckboxWithRequiredComponent);
@@ -658,6 +660,10 @@ describe('Checkbox component', () => {
         checkboxElement = fixture.debugElement.query(By.directive(SkyCheckboxComponent));
         checkboxNativeElement = checkboxElement.nativeElement;
         inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+        ngModel = <NgModel> checkboxElement.injector.get(NgModel);
+        labelElement =
+          <HTMLLabelElement>checkboxElement
+            .nativeElement.querySelector('label.sky-checkbox-wrapper');
       });
     }));
 
@@ -668,6 +674,15 @@ describe('Checkbox component', () => {
         expect(inputElement.getAttribute('required')).not.toBeNull();
         expect(inputElement.getAttribute('aria-required')).toEqual('true');
       });
+    }));
+
+    it('should mark form as invalid when required checkbox is not checked', async(() => {
+      fixture.detectChanges();
+      expect(ngModel.valid).toBe(false);
+      labelElement.click();
+      expect(ngModel.valid).toBe(true);
+      labelElement.click();
+      expect(ngModel.valid).toBe(false);
     }));
   });
 
@@ -773,8 +788,11 @@ describe('Checkbox component', () => {
 
   describe('with reactive form and required', () => {
     let checkboxElement: DebugElement;
+    let testComponent: CheckboxWithReactiveFormComponent;
     let inputElement: HTMLInputElement;
     let checkboxNativeElement: HTMLElement;
+    let formControl: FormControl;
+    let labelElement: HTMLLabelElement;
 
     beforeEach(async(() => {
       fixture = TestBed.createComponent(CheckboxWithReactiveFormRequiredComponent);
@@ -783,7 +801,12 @@ describe('Checkbox component', () => {
       fixture.whenStable().then(() => {
         checkboxElement = fixture.debugElement.query(By.directive(SkyCheckboxComponent));
         checkboxNativeElement = checkboxElement.nativeElement;
+        testComponent = fixture.debugElement.componentInstance;
         inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+        formControl = testComponent.checkbox1;
+        labelElement =
+          <HTMLLabelElement>checkboxElement
+            .nativeElement.querySelector('label.sky-checkbox-wrapper');
       });
     }));
 
@@ -794,6 +817,15 @@ describe('Checkbox component', () => {
         expect(inputElement.getAttribute('required')).not.toBeNull();
         expect(inputElement.getAttribute('aria-required')).toEqual('true');
       });
+    }));
+
+    it('should mark form as invalid when required checkbox is not checked', async(() => {
+      fixture.detectChanges();
+      expect(formControl.valid).toBe(false);
+      labelElement.click();
+      expect(formControl.valid).toBe(true);
+      labelElement.click();
+      expect(formControl.valid).toBe(false);
     }));
   });
 

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -682,6 +682,13 @@ describe('Checkbox component', () => {
         expect(inputElement.getAttribute('aria-required')).toBeNull();
       });
     });
+
+    it('should not have "sky-control-label-required" class', () => {
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(labelElement).not.toHaveCssClass('sky-control-label-required');
+      });
+    });
   });
 
   describe('with ngModel and required input', () => {
@@ -716,6 +723,13 @@ describe('Checkbox component', () => {
         expect(inputElement.getAttribute('aria-required')).toEqual('true');
       });
     }));
+
+    it('should have "sky-control-label-required" class', () => {
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(labelElement).toHaveCssClass('sky-control-label-required');
+      });
+    });
 
     it('should not have required and aria-reqiured attributes when input is false', async(() => {
       fixture.detectChanges();

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -15,13 +15,12 @@ import {
 } from '@angular/platform-browser';
 import {
   FormsModule,
+  NgForm,
   NgModel,
   FormControl,
   FormGroup,
   ReactiveFormsModule,
-  Validators,
-  NgControl,
-  NgForm
+  Validators
 } from '@angular/forms';
 
 import {

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -614,7 +614,7 @@ describe('Checkbox component', () => {
       });
     }));
 
-    fit('should not have required and aria-reqiured attributes', () => {
+    it('should not have required and aria-reqiured attributes', () => {
       fixture.whenStable().then(() => {
         fixture.detectChanges();
         expect(inputElement.getAttribute('required')).toBeNull();
@@ -639,7 +639,7 @@ describe('Checkbox component', () => {
       });
     }));
 
-    fit('should have required and aria-reqiured attributes', async(() => {
+    it('should have required and aria-reqiured attributes', async(() => {
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         fixture.detectChanges();

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -18,7 +18,8 @@ import {
   NgModel,
   FormControl,
   FormGroup,
-  ReactiveFormsModule
+  ReactiveFormsModule,
+  Validators
 } from '@angular/forms';
 
 import {
@@ -65,7 +66,7 @@ class SingleCheckboxComponent {
   template: `
   <div>
     <form>
-      <sky-checkbox name="cb"  [(ngModel)]="isGood" [attr.required]="(required) ? true : null" #wut>
+      <sky-checkbox name="cb" [(ngModel)]="isGood" #wut>
         <sky-checkbox-label>
           Be good
         </sky-checkbox-label>
@@ -113,6 +114,26 @@ class CheckboxWithRequiredComponent {
 })
 class CheckboxWithReactiveFormComponent {
   public checkbox1: FormControl = new FormControl(false);
+
+  public checkboxForm = new FormGroup({'checkbox1': this.checkbox1});
+}
+
+/** Simple component for testing a reactive form checkbox with required validator. */
+@Component({
+  template: `
+  <div>
+    <form [formGroup]="checkboxForm">
+      <sky-checkbox name="cb" formControlName="checkbox1" #wut>
+        <sky-checkbox-label>
+          Be good
+        </sky-checkbox-label>
+      </sky-checkbox>
+    </form>
+  </div>
+  `
+})
+class CheckboxWithReactiveFormRequiredComponent {
+  public checkbox1: FormControl = new FormControl(false, Validators.required);
 
   public checkboxForm = new FormGroup({'checkbox1': this.checkbox1});
 }
@@ -204,6 +225,7 @@ describe('Checkbox component', () => {
         CheckboxWithOnPushChangeDetectionComponent,
         CheckboxWithTabIndexComponent,
         CheckboxWithReactiveFormComponent,
+        CheckboxWithReactiveFormRequiredComponent,
         CheckboxWithRequiredComponent,
         MultipleCheckboxesComponent,
         SingleCheckboxComponent
@@ -614,7 +636,7 @@ describe('Checkbox component', () => {
       });
     }));
 
-    it('should not have required and aria-reqiured attributes', () => {
+    it('should not have required and aria-reqiured attributes when not required', () => {
       fixture.whenStable().then(() => {
         fixture.detectChanges();
         expect(inputElement.getAttribute('required')).toBeNull();
@@ -737,6 +759,40 @@ describe('Checkbox component', () => {
             expect(inputElement.checked).toBe(false);
           });
         });
+      });
+    }));
+
+    it('should not have required and aria-reqiured attributes when not required', () => {
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(inputElement.getAttribute('required')).toBeNull();
+        expect(inputElement.getAttribute('aria-required')).toBeNull();
+      });
+    });
+  });
+
+  describe('with reactive form and required', () => {
+    let checkboxElement: DebugElement;
+    let inputElement: HTMLInputElement;
+    let checkboxNativeElement: HTMLElement;
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(CheckboxWithReactiveFormRequiredComponent);
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        checkboxElement = fixture.debugElement.query(By.directive(SkyCheckboxComponent));
+        checkboxNativeElement = checkboxElement.nativeElement;
+        inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+      });
+    }));
+
+    it('should have required and aria-reqiured attributes', async(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(inputElement.getAttribute('required')).not.toBeNull();
+        expect(inputElement.getAttribute('aria-required')).toEqual('true');
       });
     }));
   });

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -965,7 +965,7 @@ describe('Checkbox component', () => {
       });
     }));
 
-    fit('should update validator when required input is changed', async(() => {
+    it('should update validator when required input is changed', async(() => {
       fixture.detectChanges();
       expect(formControl.valid).toBe(false);
       testComponent.required = false;

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -77,7 +77,6 @@ class SingleCheckboxComponent {
 })
 class CheckboxWithFormDirectivesComponent {
   public isGood: boolean = false;
-  public required: boolean = false;
 }
 
 /** Simple component for testing a required template-driven checkbox. */
@@ -85,7 +84,7 @@ class CheckboxWithFormDirectivesComponent {
   template: `
   <div>
     <form>
-      <sky-checkbox name="cb" ngModel required>
+      <sky-checkbox name="cb" ngModel [required]="required">
         <sky-checkbox-label>
           Be good
         </sky-checkbox-label>
@@ -95,7 +94,7 @@ class CheckboxWithFormDirectivesComponent {
   `
 })
 class CheckboxWithRequiredComponent {
-
+  public required = true;
 }
 
 /** Simple component for testing an MdCheckbox with ngModel. */
@@ -114,7 +113,25 @@ class CheckboxWithRequiredComponent {
 })
 class CheckboxWithReactiveFormComponent {
   public checkbox1: FormControl = new FormControl(false);
+  public checkboxForm = new FormGroup({'checkbox1': this.checkbox1});
+}
 
+/** Simple component for testing a reactive form checkbox with required validator. */
+@Component({
+  template: `
+  <div>
+    <form [formGroup]="checkboxForm">
+      <sky-checkbox name="cb" formControlName="checkbox1" [required]="true" #wut>
+        <sky-checkbox-label>
+          Be good
+        </sky-checkbox-label>
+      </sky-checkbox>
+    </form>
+  </div>
+  `
+})
+class CheckboxWithReactiveFormRequiredInputComponent {
+  public checkbox1: FormControl = new FormControl(false);
   public checkboxForm = new FormGroup({'checkbox1': this.checkbox1});
 }
 
@@ -132,9 +149,8 @@ class CheckboxWithReactiveFormComponent {
   </div>
   `
 })
-class CheckboxWithReactiveFormRequiredComponent {
-  public checkbox1: FormControl = new FormControl(false, Validators.required);
-
+class CheckboxWithReactiveFormRequiredValidatorComponent {
+  public checkbox1: FormControl = new FormControl(false, Validators.requiredTrue);
   public checkboxForm = new FormGroup({'checkbox1': this.checkbox1});
 }
 
@@ -225,7 +241,8 @@ describe('Checkbox component', () => {
         CheckboxWithOnPushChangeDetectionComponent,
         CheckboxWithTabIndexComponent,
         CheckboxWithReactiveFormComponent,
-        CheckboxWithReactiveFormRequiredComponent,
+        CheckboxWithReactiveFormRequiredInputComponent,
+        CheckboxWithReactiveFormRequiredValidatorComponent,
         CheckboxWithRequiredComponent,
         MultipleCheckboxesComponent,
         SingleCheckboxComponent
@@ -676,7 +693,7 @@ describe('Checkbox component', () => {
       });
     }));
 
-    it('should mark form as invalid when required checkbox is not checked', async(() => {
+    it('should mark form as invalid when required input is true and checkbox is not checked', async(() => {
       fixture.detectChanges();
       expect(ngModel.valid).toBe(false);
       labelElement.click();
@@ -786,16 +803,59 @@ describe('Checkbox component', () => {
     });
   });
 
-  describe('with reactive form and required', () => {
+  describe('with reactive form and required validator', () => {
     let checkboxElement: DebugElement;
-    let testComponent: CheckboxWithReactiveFormComponent;
+    let testComponent: CheckboxWithReactiveFormRequiredValidatorComponent;
     let inputElement: HTMLInputElement;
     let checkboxNativeElement: HTMLElement;
     let formControl: FormControl;
     let labelElement: HTMLLabelElement;
 
     beforeEach(async(() => {
-      fixture = TestBed.createComponent(CheckboxWithReactiveFormRequiredComponent);
+      fixture = TestBed.createComponent(CheckboxWithReactiveFormRequiredValidatorComponent);
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        checkboxElement = fixture.debugElement.query(By.directive(SkyCheckboxComponent));
+        checkboxNativeElement = checkboxElement.nativeElement;
+        testComponent = fixture.debugElement.componentInstance;
+        inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+        formControl = testComponent.checkbox1;
+        labelElement =
+          <HTMLLabelElement>checkboxElement
+            .nativeElement.querySelector('label.sky-checkbox-wrapper');
+      });
+    }));
+
+    it('should have required and aria-reqiured attributes', async(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(inputElement.getAttribute('required')).not.toBeNull();
+        expect(inputElement.getAttribute('aria-required')).toEqual('true');
+      });
+    }));
+
+    it('should mark form as invalid when required checkbox is not checked', async(() => {
+      fixture.detectChanges();
+      expect(formControl.valid).toBe(false);
+      labelElement.click();
+      expect(formControl.valid).toBe(true);
+      labelElement.click();
+      expect(formControl.valid).toBe(false);
+    }));
+  });
+
+  describe('with reactive form and required input', () => {
+    let checkboxElement: DebugElement;
+    let testComponent: CheckboxWithReactiveFormRequiredInputComponent;
+    let inputElement: HTMLInputElement;
+    let checkboxNativeElement: HTMLElement;
+    let formControl: FormControl;
+    let labelElement: HTMLLabelElement;
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(CheckboxWithReactiveFormRequiredInputComponent);
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -19,7 +19,9 @@ import {
   FormControl,
   FormGroup,
   ReactiveFormsModule,
-  Validators
+  Validators,
+  NgControl,
+  NgForm
 } from '@angular/forms';
 
 import {
@@ -137,7 +139,7 @@ class CheckboxWithReactiveFormComponent {
   template: `
   <div>
     <form [formGroup]="checkboxForm">
-      <sky-checkbox name="cb" formControlName="checkbox1" [required]="true" #wut>
+      <sky-checkbox name="cb" formControlName="checkbox1" [required]="required" #wut>
         <sky-checkbox-label>
           Be good
         </sky-checkbox-label>
@@ -149,6 +151,7 @@ class CheckboxWithReactiveFormComponent {
 class CheckboxWithReactiveFormRequiredInputComponent {
   public checkbox1: FormControl = new FormControl(false);
   public checkboxForm = new FormGroup({'checkbox1': this.checkbox1});
+  public required = true;
 }
 
 /** Simple component for testing a reactive form checkbox with required validator. */
@@ -269,6 +272,9 @@ describe('Checkbox component', () => {
         FormsModule,
         ReactiveFormsModule,
         SkyCheckboxModule
+      ],
+      providers: [
+        NgForm
       ]
     });
   });
@@ -957,6 +963,17 @@ describe('Checkbox component', () => {
         expect(inputElement.getAttribute('required')).not.toBeNull();
         expect(inputElement.getAttribute('aria-required')).toEqual('true');
       });
+    }));
+
+    fit('should update validator when required input is changed', async(() => {
+      fixture.detectChanges();
+      expect(formControl.valid).toBe(false);
+      testComponent.required = false;
+      fixture.detectChanges();
+      expect(formControl.valid).toBe(true);
+      testComponent.required = true;
+      fixture.detectChanges();
+      expect(formControl.valid).toBe(false);
     }));
 
     it('should mark form as invalid when required checkbox is not checked', async(() => {

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -84,7 +84,7 @@ class CheckboxWithFormDirectivesComponent {
   template: `
   <div>
     <form>
-      <sky-checkbox name="cb" ngModel [required]="required">
+      <sky-checkbox name="cb" ngModel [required]="true">
         <sky-checkbox-label>
           Be good
         </sky-checkbox-label>
@@ -93,9 +93,7 @@ class CheckboxWithFormDirectivesComponent {
   </div>
   `
 })
-class CheckboxWithRequiredComponent {
-  public required = true;
-}
+class CheckboxWithRequiredComponent {}
 
 /** Simple component for testing an MdCheckbox with ngModel. */
 @Component({

--- a/src/app/public/modules/checkbox/checkbox.component.spec.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.spec.ts
@@ -84,7 +84,7 @@ class CheckboxWithFormDirectivesComponent {
   template: `
   <div>
     <form>
-      <sky-checkbox name="cb" ngModel [required]="true">
+      <sky-checkbox name="cb" ngModel [required]="required">
         <sky-checkbox-label>
           Be good
         </sky-checkbox-label>
@@ -93,7 +93,25 @@ class CheckboxWithFormDirectivesComponent {
   </div>
   `
 })
-class CheckboxWithRequiredComponent {}
+class CheckboxWithRequiredInputComponent {
+  public required = true;
+}
+
+/** Simple component for testing a required template-driven checkbox. */
+@Component({
+  template: `
+  <div>
+    <form>
+      <sky-checkbox name="cb" ngModel required>
+        <sky-checkbox-label>
+          Be good
+        </sky-checkbox-label>
+      </sky-checkbox>
+    </form>
+  </div>
+  `
+})
+class CheckboxWithRequiredAttributeComponent {}
 
 /** Simple component for testing an MdCheckbox with ngModel. */
 @Component({
@@ -241,7 +259,8 @@ describe('Checkbox component', () => {
         CheckboxWithReactiveFormComponent,
         CheckboxWithReactiveFormRequiredInputComponent,
         CheckboxWithReactiveFormRequiredValidatorComponent,
-        CheckboxWithRequiredComponent,
+        CheckboxWithRequiredAttributeComponent,
+        CheckboxWithRequiredInputComponent,
         MultipleCheckboxesComponent,
         SingleCheckboxComponent
       ],
@@ -660,7 +679,70 @@ describe('Checkbox component', () => {
     });
   });
 
-  describe('with ngModel and required', () => {
+  describe('with ngModel and required input', () => {
+    let checkboxElement: DebugElement;
+    let testComponent: CheckboxWithRequiredInputComponent;
+    let inputElement: HTMLInputElement;
+    let checkboxNativeElement: HTMLElement;
+    let ngModel: NgModel;
+    let labelElement: HTMLLabelElement;
+
+    beforeEach(async(() => {
+      fixture = TestBed.createComponent(CheckboxWithRequiredInputComponent);
+      fixture.detectChanges();
+
+      fixture.whenStable().then(() => {
+        checkboxElement = fixture.debugElement.query(By.directive(SkyCheckboxComponent));
+        testComponent = fixture.componentInstance;
+        checkboxNativeElement = checkboxElement.nativeElement;
+        inputElement = <HTMLInputElement>checkboxNativeElement.querySelector('input');
+        ngModel = <NgModel> checkboxElement.injector.get(NgModel);
+        labelElement =
+          <HTMLLabelElement>checkboxElement
+            .nativeElement.querySelector('label.sky-checkbox-wrapper');
+      });
+    }));
+
+    it('should have required and aria-reqiured attributes', async(() => {
+      fixture.detectChanges();
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(inputElement.getAttribute('required')).not.toBeNull();
+        expect(inputElement.getAttribute('aria-required')).toEqual('true');
+      });
+    }));
+
+    it('should not have required and aria-reqiured attributes when input is false', async(() => {
+      fixture.detectChanges();
+      testComponent.required = false;
+      fixture.whenStable().then(() => {
+        fixture.detectChanges();
+        expect(inputElement.getAttribute('required')).toBeNull();
+        expect(inputElement.getAttribute('aria-required')).not.toEqual('true');
+      });
+    }));
+
+    it('should mark form as invalid when required input is true and checkbox is not checked', async(() => {
+      fixture.detectChanges();
+      expect(ngModel.valid).toBe(false);
+      labelElement.click();
+      expect(ngModel.valid).toBe(true);
+      labelElement.click();
+      expect(ngModel.valid).toBe(false);
+    }));
+
+    it('should not mark form as invalid when required input is false and checkbox is not checked', async(() => {
+      testComponent.required = false;
+      fixture.detectChanges();
+      expect(ngModel.valid).toBe(true);
+      labelElement.click();
+      expect(ngModel.valid).toBe(true);
+      labelElement.click();
+      expect(ngModel.valid).toBe(true);
+    }));
+  });
+
+  describe('with ngModel and required attribute', () => {
     let checkboxElement: DebugElement;
     let inputElement: HTMLInputElement;
     let checkboxNativeElement: HTMLElement;
@@ -668,7 +750,7 @@ describe('Checkbox component', () => {
     let labelElement: HTMLLabelElement;
 
     beforeEach(async(() => {
-      fixture = TestBed.createComponent(CheckboxWithRequiredComponent);
+      fixture = TestBed.createComponent(CheckboxWithRequiredAttributeComponent);
       fixture.detectChanges();
 
       fixture.whenStable().then(() => {

--- a/src/app/public/modules/checkbox/checkbox.component.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.ts
@@ -1,6 +1,5 @@
 
 import {
-  AfterViewInit,
   Component,
   EventEmitter,
   forwardRef,
@@ -55,7 +54,7 @@ export class SkyCheckboxChange {
     SKY_CHECKBOX_VALIDATOR
   ]
 })
-export class SkyCheckboxComponent implements AfterViewInit, ControlValueAccessor, Validator {
+export class SkyCheckboxComponent implements ControlValueAccessor, Validator {
 
   /**
    * Hidden label for screen readers.
@@ -127,9 +126,6 @@ export class SkyCheckboxComponent implements AfterViewInit, ControlValueAccessor
   private isFirstChange = true;
   private _checkboxType: string;
   private _checked: boolean = false;
-
-  public ngAfterViewInit(): void {
-  }
 
   /**
    * Implemented as part of ControlValueAccessor.

--- a/src/app/public/modules/checkbox/checkbox.component.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.ts
@@ -1,5 +1,6 @@
 
 import {
+  AfterViewInit,
   Component,
   EventEmitter,
   forwardRef,
@@ -10,10 +11,11 @@ import {
 import {
   AbstractControl,
   ControlValueAccessor,
+  FormControl,
+  NG_VALIDATORS,
   NG_VALUE_ACCESSOR,
   ValidationErrors,
-  Validator,
-  NG_VALIDATORS
+  Validator
 } from '@angular/forms';
 
 /**
@@ -37,13 +39,13 @@ const SKY_CHECKBOX_VALIDATOR = {
   useExisting: forwardRef(() => SkyCheckboxComponent),
   multi: true
 };
+// tslint:enable
 
 // A simple change event emitted by the SkyCheckbox component.
 export class SkyCheckboxChange {
   public source: SkyCheckboxComponent;
   public checked: boolean;
 }
-// tslint:enable
 
 @Component({
   selector: 'sky-checkbox',
@@ -53,7 +55,7 @@ export class SkyCheckboxChange {
     SKY_CHECKBOX_VALIDATOR
   ]
 })
-export class SkyCheckboxComponent implements ControlValueAccessor, Validator {
+export class SkyCheckboxComponent implements AfterViewInit, ControlValueAccessor, Validator {
 
   /**
    * Hidden label for screen readers.
@@ -119,10 +121,15 @@ export class SkyCheckboxComponent implements ControlValueAccessor, Validator {
     return this._checked;
   }
 
+  public required: boolean = false;
+
   private control: AbstractControl;
   private isFirstChange = true;
   private _checkboxType: string;
   private _checked: boolean = false;
+
+  public ngAfterViewInit(): void {
+  }
 
   /**
    * Implemented as part of ControlValueAccessor.
@@ -175,6 +182,15 @@ export class SkyCheckboxComponent implements ControlValueAccessor, Validator {
   public validate(control: AbstractControl): ValidationErrors {
     if (!this.control) {
       this.control = control;
+
+      const vf = this.control.validator(new FormControl());
+      this.required = vf ? vf.required : undefined;
+    }
+
+    if (this.required && !control.value) {
+      return {
+        'required': true
+      };
     }
 
     return;

--- a/src/app/public/modules/checkbox/checkbox.component.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.ts
@@ -179,6 +179,8 @@ export class SkyCheckboxComponent implements ControlValueAccessor, Validator {
     if (!this.control) {
       this.control = control;
 
+      // Get required state from AbstractControl.
+      // https://github.com/angular/components/issues/2574#issuecomment-461185408
       const vf = this.control.validator(new FormControl());
       this.required = vf ? vf.required : undefined;
     }

--- a/src/app/public/modules/checkbox/checkbox.module.ts
+++ b/src/app/public/modules/checkbox/checkbox.module.ts
@@ -1,10 +1,11 @@
-// #region imports
-import {
-  NgModule
-} from '@angular/core';
 import {
   CommonModule
 } from '@angular/common';
+
+import {
+  NgModule
+} from '@angular/core';
+
 import {
   FormsModule
 } from '@angular/forms';
@@ -14,17 +15,22 @@ import {
 } from '@skyux/indicators';
 
 import {
-  SkyCheckboxLabelComponent
-} from './checkbox-label.component';
-import {
   SkyCheckboxComponent
 } from './checkbox.component';
-// #endregion
+
+import {
+  SkyCheckboxLabelComponent
+} from './checkbox-label.component';
+
+import {
+  SkyCheckboxRequiredValidatorDirective
+} from './checkbox-required-validator.directive';
 
 @NgModule({
   declarations: [
     SkyCheckboxComponent,
-    SkyCheckboxLabelComponent
+    SkyCheckboxLabelComponent,
+    SkyCheckboxRequiredValidatorDirective
   ],
   imports: [
     CommonModule,
@@ -33,7 +39,8 @@ import {
   ],
   exports: [
     SkyCheckboxComponent,
-    SkyCheckboxLabelComponent
+    SkyCheckboxLabelComponent,
+    SkyCheckboxRequiredValidatorDirective
   ]
 })
 export class SkyCheckboxModule { }

--- a/src/app/visual/checkbox/checkbox-visual.component.html
+++ b/src/app/visual/checkbox/checkbox-visual.component.html
@@ -77,9 +77,7 @@
       [required]="required"
       #templateDrivenCheckbox="ngModel"
     >
-      <sky-checkbox-label
-        [ngClass]="{'sky-control-label-required' : required}"
-      >
+      <sky-checkbox-label>
         Check me
       </sky-checkbox-label>
     </sky-checkbox>
@@ -114,9 +112,7 @@
         [required]="required"
         formControlName="reactiveCheckbox"
       >
-        <sky-checkbox-label
-          [ngClass]="{'sky-control-label-required' : required}"
-        >
+        <sky-checkbox-label>
           Check me
         </sky-checkbox-label>
       </sky-checkbox>

--- a/src/app/visual/checkbox/checkbox-visual.component.html
+++ b/src/app/visual/checkbox/checkbox-visual.component.html
@@ -66,7 +66,8 @@
     [checked]="false">
   </sky-checkbox>
 </div>
-<div>
+
+<div id="template-driven-checkbox">
   <h3>
     Template-driven checkbox
   </h3>
@@ -74,7 +75,7 @@
     <sky-checkbox
       ngModel
       [required]="required"
-      #fooModel="ngModel"
+      #templateDrivenCheckbox="ngModel"
     >
       <sky-checkbox-label
         [ngClass]="{'sky-control-label-required' : required}"
@@ -87,18 +88,20 @@
   <table>
     <tr>
       <th>Touched</th>
-      <td>{{ fooModel.touched }}</td>
+      <td>{{ templateDrivenCheckbox.touched }}</td>
     </tr>
     <tr>
       <th>Pristine</th>
-      <td>{{ fooModel.pristine }}</td>
+      <td>{{ templateDrivenCheckbox.pristine }}</td>
     </tr>
     <tr>
       <th>Valid</th>
-      <td>{{ fooModel.valid }}</td>
+      <td>{{ templateDrivenCheckbox.valid }}</td>
     </tr>
   </table>
+</div>
 
+<div id="reactive-checkbox">
   <h3>
     Reactive checkbox
   </h3>
@@ -108,6 +111,7 @@
     novalidate
   >
       <sky-checkbox
+        [required]="required"
         formControlName="reactiveCheckbox"
       >
         <sky-checkbox-label

--- a/src/app/visual/checkbox/checkbox-visual.component.html
+++ b/src/app/visual/checkbox/checkbox-visual.component.html
@@ -1,4 +1,4 @@
-<!-- <div id="screenshot-checkbox">
+<div id="screenshot-checkbox">
   <sky-checkbox [checked]="true">
     <sky-checkbox-label>Checked Checkbox</sky-checkbox-label>
   </sky-checkbox>
@@ -65,7 +65,7 @@
     label="wrong"
     [checked]="false">
   </sky-checkbox>
-</div> -->
+</div>
 <div>
   <h3>
     Template-driven checkbox
@@ -73,7 +73,7 @@
   <p>
     <sky-checkbox
       ngModel
-      required
+      [required]="required"
       #fooModel="ngModel"
     >
       <sky-checkbox-label
@@ -99,7 +99,7 @@
     </tr>
   </table>
 
-  <!-- <h3>
+  <h3>
     Reactive checkbox
   </h3>
 
@@ -131,7 +131,7 @@
       <th>Valid</th>
       <td>{{ reactiveFormGroup.valid }}</td>
     </tr>
-  </table> -->
+  </table>
 </div>
 
 <button (click)="toggleRequired()">Toggle required</button>

--- a/src/app/visual/checkbox/checkbox-visual.component.html
+++ b/src/app/visual/checkbox/checkbox-visual.component.html
@@ -66,3 +66,70 @@
     [checked]="false">
   </sky-checkbox>
 </div>
+<div>
+  <h3>
+    Template-driven checkbox
+  </h3>
+  <p>
+    <sky-checkbox
+      required
+      ngModel
+      #fooModel="ngModel"
+    >
+      <sky-checkbox-label
+        class="sky-control-label-required"
+      >
+        Checked Checkbox
+      </sky-checkbox-label>
+    </sky-checkbox>
+  </p>
+
+  <table>
+    <tr>
+      <th>Touched</th>
+      <td>{{ fooModel.touched }}</td>
+    </tr>
+    <tr>
+      <th>Pristine</th>
+      <td>{{ fooModel.pristine }}</td>
+    </tr>
+    <tr>
+      <th>Valid</th>
+      <td>{{ fooModel.valid }}</td>
+    </tr>
+  </table>
+
+  <h3>
+    Reactive checkbox
+  </h3>
+
+  <form
+    [formGroup]="reactiveFormGroup"
+    novalidate
+  >
+      <sky-checkbox
+        formControlName="reactiveCheckbox"
+      >
+        <sky-checkbox-label
+          class="sky-control-label-required"
+        >
+          Unchecked Checkbox
+        </sky-checkbox-label>
+      </sky-checkbox>
+  </form>
+
+  <table>
+    <tr>
+      <th>Touched</th>
+      <td>{{ reactiveFormGroup.touched }}</td>
+    </tr>
+    <tr>
+      <th>Pristine</th>
+      <td>{{ reactiveFormGroup.pristine }}</td>
+    </tr>
+    <tr>
+      <th>Valid</th>
+      <td>{{ reactiveFormGroup.valid }}</td>
+    </tr>
+  </table>
+</div>

--- a/src/app/visual/checkbox/checkbox-visual.component.html
+++ b/src/app/visual/checkbox/checkbox-visual.component.html
@@ -79,7 +79,7 @@
       <sky-checkbox-label
         class="sky-control-label-required"
       >
-        Checked Checkbox
+        Check me
       </sky-checkbox-label>
     </sky-checkbox>
   </p>
@@ -113,7 +113,7 @@
         <sky-checkbox-label
           class="sky-control-label-required"
         >
-          Unchecked Checkbox
+          Check me
         </sky-checkbox-label>
       </sky-checkbox>
   </form>

--- a/src/app/visual/checkbox/checkbox-visual.component.html
+++ b/src/app/visual/checkbox/checkbox-visual.component.html
@@ -1,4 +1,4 @@
-<div id="screenshot-checkbox">
+<!-- <div id="screenshot-checkbox">
   <sky-checkbox [checked]="true">
     <sky-checkbox-label>Checked Checkbox</sky-checkbox-label>
   </sky-checkbox>
@@ -65,19 +65,19 @@
     label="wrong"
     [checked]="false">
   </sky-checkbox>
-</div>
+</div> -->
 <div>
   <h3>
     Template-driven checkbox
   </h3>
   <p>
     <sky-checkbox
-      required
       ngModel
+      required
       #fooModel="ngModel"
     >
       <sky-checkbox-label
-        class="sky-control-label-required"
+        [ngClass]="{'sky-control-label-required' : required}"
       >
         Check me
       </sky-checkbox-label>
@@ -99,7 +99,7 @@
     </tr>
   </table>
 
-  <h3>
+  <!-- <h3>
     Reactive checkbox
   </h3>
 
@@ -111,7 +111,7 @@
         formControlName="reactiveCheckbox"
       >
         <sky-checkbox-label
-          class="sky-control-label-required"
+          [ngClass]="{'sky-control-label-required' : required}"
         >
           Check me
         </sky-checkbox-label>
@@ -131,5 +131,7 @@
       <th>Valid</th>
       <td>{{ reactiveFormGroup.valid }}</td>
     </tr>
-  </table>
+  </table> -->
 </div>
+
+<button (click)="toggleRequired()">Toggle required</button>

--- a/src/app/visual/checkbox/checkbox-visual.component.ts
+++ b/src/app/visual/checkbox/checkbox-visual.component.ts
@@ -23,14 +23,27 @@ export class CheckboxVisualComponent implements OnInit {
 
   public reactiveFormGroup: FormGroup;
 
+  public required: boolean = true;
+
   constructor(
     private formBuilder: FormBuilder
   ) { }
 
   public ngOnInit(): void {
     this.reactiveFormGroup = this.formBuilder.group(
-      { reactiveCheckbox: [ undefined, Validators.required ] }
+      { reactiveCheckbox: [ undefined, Validators.requiredTrue ] }
     );
+  }
+
+  public toggleRequired(): void {
+    this.required = !this.required;
+    if (this.required) {
+      this.reactiveFormGroup.get('reactiveCheckbox').setValidators(Validators.requiredTrue);
+    } else {
+      this.reactiveFormGroup.get('reactiveCheckbox').setValidators(undefined);
+    }
+
+    this.reactiveFormGroup.get('reactiveCheckbox').updateValueAndValidity();
   }
 
 }

--- a/src/app/visual/checkbox/checkbox-visual.component.ts
+++ b/src/app/visual/checkbox/checkbox-visual.component.ts
@@ -1,11 +1,36 @@
-import { Component } from '@angular/core';
+import {
+  Component,
+  OnInit
+} from '@angular/core';
+
+import {
+  FormBuilder,
+  FormGroup,
+  Validators
+} from '@angular/forms';
 
 @Component({
   selector: 'checkbox-visual',
   templateUrl: './checkbox-visual.component.html'
 })
-export class CheckboxVisualComponent {
+export class CheckboxVisualComponent implements OnInit {
 
   public checkValue: boolean = true;
+
+  public foo: boolean;
+
+  public bar: boolean;
+
+  public reactiveFormGroup: FormGroup;
+
+  constructor(
+    private formBuilder: FormBuilder
+  ) { }
+
+  public ngOnInit(): void {
+    this.reactiveFormGroup = this.formBuilder.group(
+      { reactiveCheckbox: [ undefined, Validators.required ] }
+    );
+  }
 
 }

--- a/src/app/visual/checkbox/checkbox-visual.component.ts
+++ b/src/app/visual/checkbox/checkbox-visual.component.ts
@@ -5,8 +5,7 @@ import {
 
 import {
   FormBuilder,
-  FormGroup,
-  Validators
+  FormGroup
 } from '@angular/forms';
 
 @Component({
@@ -31,19 +30,12 @@ export class CheckboxVisualComponent implements OnInit {
 
   public ngOnInit(): void {
     this.reactiveFormGroup = this.formBuilder.group(
-      { reactiveCheckbox: [ undefined, Validators.requiredTrue ] }
+      { reactiveCheckbox: [ undefined ] }
     );
   }
 
   public toggleRequired(): void {
     this.required = !this.required;
-    if (this.required) {
-      this.reactiveFormGroup.get('reactiveCheckbox').setValidators(Validators.requiredTrue);
-    } else {
-      this.reactiveFormGroup.get('reactiveCheckbox').setValidators(undefined);
-    }
-
-    this.reactiveFormGroup.get('reactiveCheckbox').updateValueAndValidity();
   }
 
 }


### PR DESCRIPTION
New `@Input()` property:

`required` - Indicates if the checkbox must be checked to be valid. This property accepts a boolean values.

Impact of setting `required` to `true`:
- `aria-required` attribute added to `input` element
- `required` attribute added to `input` element
- Angular form should show invalid state when checkbox isn't checked

This works with both template-driven & reactive forms.