### PR TITLE
Added missing null check

### DIFF
--- a/src/app/public/modules/checkbox/checkbox.component.ts
+++ b/src/app/public/modules/checkbox/checkbox.component.ts
@@ -88,7 +88,7 @@ export class SkyCheckboxComponent implements ControlValueAccessor, OnInit {
 
       // Do not mark the field as "dirty"
       // if the field has been initialized with a value.
-      if (this.isFirstChange && this.ngControl) {
+      if (this.isFirstChange && this.ngControl && this.ngControl.control) {
         this.ngControl.control.markAsPristine();
         this.isFirstChange = false;
       }


### PR DESCRIPTION
Addresses #84 

Sometimes forms that created dynamically with an ngIf won't fully have a Abstract Control when our logic runs. We just needed a null check for that control to avoid these bugs.