### PR TITLE
Fix character counter directive to not overwrite value accessor

### DIFF
--- a/src/app/public/modules/character-counter/character-counter.component.spec.ts
+++ b/src/app/public/modules/character-counter/character-counter.component.spec.ts
@@ -7,8 +7,7 @@ import {
 } from '@angular/core/testing';
 
 import {
-  expect,
-  SkyAppTestUtility
+  expect
 } from '@skyux-sdk/testing';
 
 import {
@@ -29,30 +28,11 @@ import {
 
 describe('Character Counter component', () => {
 
-  function setInputWithKeyupEvent(
-    element: HTMLElement,
-    text: string,
-    fixture: ComponentFixture<any>
+  function setInputValue(
+    fixture: ComponentFixture<CharacterCountTestComponent | CharacterCountNoIndicatorTestComponent>,
+    value: string
   ): void {
-    const inputEl = element.querySelector('input');
-    inputEl.value = text;
-    fixture.detectChanges();
-
-    SkyAppTestUtility.fireDomEvent(inputEl, 'keyup');
-    fixture.detectChanges();
-    tick();
-  }
-
-  function setInputWithInputEvent(
-    element: HTMLElement,
-    text: string,
-    fixture: ComponentFixture<any>
-  ): void {
-    const inputEl = element.querySelector('input');
-    inputEl.value = text;
-    fixture.detectChanges();
-
-    SkyAppTestUtility.fireDomEvent(inputEl, 'input');
+    fixture.componentInstance.firstName.setValue(value);
     fixture.detectChanges();
     tick();
   }
@@ -89,27 +69,21 @@ describe('Character Counter component', () => {
     });
 
     it('should update the count on input', fakeAsync(() => {
-      setInputWithInputEvent(nativeElement, 'abc', fixture);
+      setInputValue(fixture, 'abc');
 
       expect(characterCountComponent.characterCount).toBe(3);
       expect(characterCountLabel.innerText.trim()).toBe('3/5');
 
-      setInputWithInputEvent(nativeElement, 'abcd', fixture);
+      setInputValue(fixture, 'abcd');
 
       expect(characterCountComponent.characterCount).toBe(4);
       expect(characterCountLabel.innerText.trim()).toBe('4/5');
     }));
 
     it('should handle undefined input', fakeAsync(() => {
-      const inputEl = nativeElement.querySelector('input');
       /* tslint:disable */
-      inputEl.value = null;
+      setInputValue(fixture, null);
       /* tslint:enable */
-      fixture.detectChanges();
-
-      SkyAppTestUtility.fireDomEvent(inputEl, 'keyup');
-      fixture.detectChanges();
-      tick();
 
       expect(characterCountComponent.characterCount).toBe(0);
       expect(characterCountLabel.innerText.trim()).toBe('0/5');
@@ -117,25 +91,23 @@ describe('Character Counter component', () => {
     }));
 
     it('should show the error icon on the character count when appropriate', fakeAsync(() => {
-      setInputWithInputEvent(nativeElement, 'abcde', fixture);
+      setInputValue(fixture, 'abcde');
       expect(characterCountLabel.classList.contains('sky-error-label')).toBeFalsy();
 
-      setInputWithInputEvent(nativeElement, 'abcdef', fixture);
+      setInputValue(fixture, 'abcdef');
       expect(characterCountLabel.classList.contains('sky-error-label')).toBeTruthy();
     }));
 
     it('should show the error detail message when appropriate', fakeAsync(() => {
-      setInputWithKeyupEvent(nativeElement, 'abcde', fixture);
+      setInputValue(fixture, 'abcde');
       expect(component.firstName.valid).toBeTruthy();
 
-      setInputWithInputEvent(nativeElement, 'abcdef', fixture);
-      expect(component.firstName.valid).toBeTruthy();
-
-      setInputWithKeyupEvent(nativeElement, 'abcdef', fixture);
+      setInputValue(fixture, 'abcdef');
       expect(component.firstName.valid).toBeFalsy();
     }));
 
     it('should handle changes to max character count', fakeAsync(() => {
+      setInputValue(fixture, '1234');
       component.setCharacterCountLimit(3);
       fixture.detectChanges();
       expect(component.firstName.valid).toBeFalsy();
@@ -145,6 +117,36 @@ describe('Character Counter component', () => {
       fixture.detectChanges();
       expect(component.firstName.valid).toBeTruthy();
       expect(characterCountLabel.classList.contains('sky-error-label')).toBeFalsy();
+    }));
+
+    it('should only update the limit if different', async(() => {
+      const spy = spyOnProperty(characterCountComponent, 'characterCountLimit', 'set').and.callThrough();
+
+      component.setCharacterCountLimit(15);
+      fixture.detectChanges();
+      expect(spy).toHaveBeenCalledWith(15);
+      spy.calls.reset();
+
+      component.setCharacterCountLimit(15);
+      fixture.detectChanges();
+      expect(spy).not.toHaveBeenCalled();
+      spy.calls.reset();
+
+      component.setCharacterCountLimit(10);
+      fixture.detectChanges();
+      expect(spy).toHaveBeenCalledWith(10);
+    }));
+
+    it('should default the limit to zero', fakeAsync(() => {
+      component.setCharacterCountLimit(5);
+      fixture.detectChanges();
+
+      expect(characterCountComponent.characterCountLimit).toEqual(5);
+
+      component.setCharacterCountLimit(undefined);
+      fixture.detectChanges();
+
+      expect(characterCountComponent.characterCountLimit).toEqual(0);
     }));
 
     it('should pass accessibility', async(() => {
@@ -158,38 +160,27 @@ describe('Character Counter component', () => {
   describe('without count indicator', () => {
     let fixture: ComponentFixture<CharacterCountNoIndicatorTestComponent>;
     let component: CharacterCountNoIndicatorTestComponent;
-    let nativeElement: HTMLElement;
 
     beforeEach(() => {
       fixture = TestBed.createComponent(CharacterCountNoIndicatorTestComponent);
-      nativeElement = fixture.nativeElement as HTMLElement;
       component = fixture.componentInstance;
 
       fixture.detectChanges();
     });
 
     it('should handle undefined input', fakeAsync(() => {
-      const inputEl = nativeElement.querySelector('input');
       /* tslint:disable */
-      inputEl.value = null;
+      setInputValue(fixture, null);
       /* tslint:enable */
-      fixture.detectChanges();
-
-      SkyAppTestUtility.fireDomEvent(inputEl, 'keyup');
-      fixture.detectChanges();
-      tick();
 
       expect(component.firstName.valid).toBeTruthy();
     }));
 
     it('should show the error detail message when appropriate', fakeAsync(() => {
-      setInputWithKeyupEvent(nativeElement, 'abcde', fixture);
+      setInputValue(fixture, 'abcde');
       expect(component.firstName.valid).toBeTruthy();
 
-      setInputWithInputEvent(nativeElement, 'abcdef', fixture);
-      expect(component.firstName.valid).toBeTruthy();
-
-      setInputWithKeyupEvent(nativeElement, 'abcdef', fixture);
+      setInputValue(fixture, 'abcdef');
       expect(component.firstName.valid).toBeFalsy();
     }));
 

--- a/src/app/public/modules/character-counter/character-counter.directive.ts
+++ b/src/app/public/modules/character-counter/character-counter.directive.ts
@@ -1,21 +1,11 @@
 import {
-  AfterViewInit,
-  ChangeDetectorRef,
   Directive,
-  ElementRef,
-  forwardRef,
-  HostListener,
-  Input,
-  OnChanges,
-  OnInit,
-  Renderer2
+  Input
 } from '@angular/core';
 
 import {
   AbstractControl,
-  ControlValueAccessor,
   NG_VALIDATORS,
-  NG_VALUE_ACCESSOR,
   ValidationErrors,
   Validator
 } from '@angular/forms';
@@ -24,164 +14,69 @@ import {
   SkyCharacterCounterIndicatorComponent
 } from './character-counter-indicator.component';
 
-// tslint:disable:no-forward-ref no-use-before-declare
-const SKY_CHARACTER_COUNT_VALUE_ACCESSOR = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => SkyCharacterCounterInputDirective),
-  multi: true
-};
-
-const SKY_CHARACTER_COUNT_VALIDATOR = {
-  provide: NG_VALIDATORS,
-  useExisting: forwardRef(() => SkyCharacterCounterInputDirective),
-  multi: true
-};
-
-// tslint:enable
 @Directive({
   selector: '[skyCharacterCounter]',
   providers: [
-    SKY_CHARACTER_COUNT_VALUE_ACCESSOR,
-    SKY_CHARACTER_COUNT_VALIDATOR
+    {
+      provide: NG_VALIDATORS,
+      useExisting: SkyCharacterCounterInputDirective,
+      multi: true
+    }
   ]
 })
-export class SkyCharacterCounterInputDirective implements
-  OnInit, ControlValueAccessor, Validator, OnChanges, AfterViewInit {
+export class SkyCharacterCounterInputDirective implements Validator {
 
   @Input()
   public skyCharacterCounterIndicator: SkyCharacterCounterIndicatorComponent;
 
   @Input()
-  public skyCharacterCounterLimit: number = 0;
-
-  private control: AbstractControl;
-
-  private get modelValue(): string {
-    return this._modelValue;
+  public set skyCharacterCounterLimit(value: number) {
+    this._skyCharacterCounterLimit = value;
+    this.updateIndicatorLimit(this.skyCharacterCounterLimit);
+    this._validatorChange();
   }
 
-  private set modelValue(value: string) {
-    if (value !== this._modelValue) {
-      this._modelValue = value;
-
-      if (this.skyCharacterCounterIndicator) {
-        this.skyCharacterCounterIndicator.characterCount = value ? value.length : 0;
-      }
-
-      this.setInputValue(value);
-      this._validatorChange();
-      this._onChange(value);
-    }
+  public get skyCharacterCounterLimit(): number {
+    return this._skyCharacterCounterLimit || 0;
   }
 
-  private _modelValue: string;
-
-  constructor(
-    private changeDetector: ChangeDetectorRef,
-    private elRef: ElementRef,
-    private renderer: Renderer2
-  ) { }
-
-  public ngOnInit(): void {
-    this.renderer.addClass(this.elRef.nativeElement, 'sky-form-control');
-
-    if (this.skyCharacterCounterIndicator) {
-      this.skyCharacterCounterIndicator.characterCountLimit = this.skyCharacterCounterLimit;
-    }
-  }
-
-  public ngAfterViewInit(): void {
-    // This is needed to address a bug in Angular 4.
-    // When a control value is set intially, its value is not represented on the view.
-    // See: https://github.com/angular/angular/issues/13792
-    // Of note is the parent check which allows us to determine if the form is reactive.
-    // Without this check there is a changed before checked error
-    /* istanbul ignore else */
-    if (this.control && this.control.parent) {
-      setTimeout(() => {
-        this.control.setValue(this.modelValue, {
-          emitEvent: false
-        });
-
-        this.changeDetector.markForCheck();
-      });
-    }
-  }
-
-  public ngOnChanges(): void {
-    // Handle changes to character count limit
-    if (this.skyCharacterCounterIndicator) {
-      this.skyCharacterCounterIndicator.characterCountLimit = this.skyCharacterCounterLimit;
-    }
-
-    // Update errors
-    if (this.control) {
-      this.control.updateValueAndValidity();
-    }
-  }
-
-  @HostListener('input', ['$event'])
-  public onInput(event: any): void {
-    this.control.markAsDirty();
-
-    if (this.skyCharacterCounterIndicator) {
-      this.skyCharacterCounterIndicator.characterCount = event.target.value.length;
-    }
-  }
-
-  @HostListener('keyup', ['$event'])
-  public onChange(event: any): void {
-    this.writeValue(event.target.value);
-  }
-
-  @HostListener('blur')
-  public onBlur /* istanbul ignore next */ (): void {
-    this._onTouched();
-  }
-
-  public registerOnChange(fn: (value: any) => any): void { this._onChange = fn; }
-  public registerOnTouched(fn: () => any): void { this._onTouched = fn; }
-  public registerOnValidatorChange(fn: () => void): void { this._validatorChange = fn; }
-
-  public writeValue(value: any): void {
-    this.modelValue = value;
-  }
+  private _skyCharacterCounterLimit: number;
 
   public validate(control: AbstractControl): ValidationErrors {
-    if (!this.control) {
-      this.control = control;
-    }
+    const value = control.value;
 
-    let value = control.value;
+    this.updateIndicatorCount(value && value.length || 0);
+
     if (!value) {
-      return undefined;
+      return;
     }
 
-    /* istanbul ignore next */
     if (value.length > this.skyCharacterCounterLimit) {
-      this.control.markAsTouched();
+      // This is needed to apply the appropriate error styles to the input.
+      control.markAsTouched();
 
       return {
         'skyCharacterCounter': {
-          invalid: control.value
+          invalid: value
         }
       };
     }
-
-    return undefined;
   }
 
-  private setInputValue(value: string): void {
-    this.renderer.setProperty(
-      this.elRef.nativeElement,
-      'value',
-      value
-    );
+  public registerOnValidatorChange(fn: () => void): void { this._validatorChange = fn; }
+
+  private updateIndicatorCount(count: number): void {
+    if (this.skyCharacterCounterIndicator) {
+      this.skyCharacterCounterIndicator.characterCount = count;
+    }
   }
 
-  /*istanbul ignore next */
-  private _onChange = (_: any) => { };
-  /*istanbul ignore next */
-  private _onTouched = () => { };
+  private updateIndicatorLimit(limit: number): void {
+    if (this.skyCharacterCounterIndicator) {
+      this.skyCharacterCounterIndicator.characterCountLimit = limit;
+    }
+  }
+
   private _validatorChange = () => { };
+
 }


### PR DESCRIPTION
This fix makes the character counter directive play nicely with other value accessors on the same `FormControl`. Originally, the directive was doing too much (writing the value to the control, etc.), when it should only be reading the value and validating it.