### PR TITLE
Update `formControlHasFocus` asynchronously

### DIFF
--- a/src/app/public/modules/input-box/input-box.component.ts
+++ b/src/app/public/modules/input-box/input-box.component.ts
@@ -100,11 +100,11 @@ export class SkyInputBoxComponent implements OnInit {
   }
 
   public formControlFocusIn(): void {
-    this.formControlHasFocus = true;
+    this.updateHasFocus(true);
   }
 
   public formControlFocusOut(): void {
-    this.formControlHasFocus = false;
+    this.updateHasFocus(false);
   }
 
   public populate(args: SkyInputBoxPopulateArgs): void {
@@ -112,6 +112,15 @@ export class SkyInputBoxComponent implements OnInit {
     this.hostButtonsTemplate = args.buttonsTemplate;
     this.hostButtonsLeftTemplate = args.buttonsLeftTemplate;
     this.hostButtonsInsetTemplate = args.buttonsInsetTemplate;
+  }
+
+  private updateHasFocus(hasFocus: boolean): void {
+    // Some components manipulate the focus of elements inside an input box programmatically,
+    // which can cause an `ExpressionChangedAfterItHasBeenCheckedError` if focus was set after
+    // initial change detection. Using `setTimeout()` here fixes it.
+    setTimeout(() => {
+      this.formControlHasFocus = hasFocus;
+    });
   }
 
   private controlHasErrors(control: AbstractControlDirective) {


### PR DESCRIPTION
This fixes an issue where components inside an input box (like the phone field) manipulate the focused element, leading to an `ExpressionChangedAfterItHasBeenCheckedError`.