### PR TITLE
Release 4.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 4.17.0 (2021-04-22)
+
+- Updated the form control line height to fit descenders. [#261](https://github.com/blackbaud/skyux-forms/pull/261)
+
 # 4.16.4 (2021-04-16)
 
 - Updated the radio group component to mark it as touched after its radio buttons lose focus. [#257](https://github.com/blackbaud/skyux-forms/pull/257)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 4.17.0 (2021-04-22)
 
-- Updated the form control line height to fit descenders. [#261](https://github.com/blackbaud/skyux-forms/pull/261)
+- Updated the form control `line-height` to fit descenders. [#261](https://github.com/blackbaud/skyux-forms/pull/261)
 
 # 4.16.4 (2021-04-16)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/forms",
-  "version": "4.16.4",
+  "version": "4.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1185,9 +1185,9 @@
       "dev": true
     },
     "@blackbaud/skyux-design-tokens": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-0.0.22.tgz",
-      "integrity": "sha512-+FCf39dpKeHhrTrrhRxRh+HNcsWk+KIyFfq0U2kl05M0EA1N3OFmrM9SY3rPv4jHS1gqEy5QwEEkX8IYyyGPHg==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@blackbaud/skyux-design-tokens/-/skyux-design-tokens-0.0.23.tgz",
+      "integrity": "sha512-ER9G0L9IxRJZWpQUX8EvbCcCQGqGzJP9tzU8eCvZJgbHCjOW48qdKL7VhCJJA8jW8cqrLRel+Fw36synq4D5QA==",
       "dev": true
     },
     "@blackbaud/skyux-lib-clipboard": {
@@ -1731,12 +1731,12 @@
       }
     },
     "@skyux/theme": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/@skyux/theme/-/theme-4.15.5.tgz",
-      "integrity": "sha512-UkrLYMfwg8Om0SyeAlsXPm19hGsozU23ulb6Tc6zmMbFX2ALmTk8/camUyl1ueKTsknH8WodmnsAMWfcuQPSeQ==",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@skyux/theme/-/theme-4.16.1.tgz",
+      "integrity": "sha512-005cgawORbJmTAObOsSHisxJlWVa0gFsA2Rf/WYobpBg0pJncllbShcqqvzL6hZyLtxlnT6WGAzEaG7W8DZENw==",
       "dev": true,
       "requires": {
-        "@blackbaud/skyux-design-tokens": "0.0.22",
+        "@blackbaud/skyux-design-tokens": "0.0.23",
         "@skyux/icons": "4.0.0-beta.2",
         "@types/fontfaceobserver": "0.0.6",
         "fontfaceobserver": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skyux/forms",
-  "version": "4.16.4",
+  "version": "4.17.0",
   "description": "SKY UX Forms",
   "scripts": {
     "build": "skyux build-public-library",
@@ -66,7 +66,7 @@
     "@skyux/popovers": "4.5.1",
     "@skyux/router": "4.1.0",
     "@skyux/tabs": "4.6.4",
-    "@skyux/theme": "4.15.5",
+    "@skyux/theme": "4.16.1",
     "codelyzer": "5.2.2",
     "rxjs": "6.6.7",
     "ts-node": "8.3.0",


### PR DESCRIPTION
- Updated the form control line height to fit descenders. [#261](https://github.com/blackbaud/skyux-forms/pull/261)
